### PR TITLE
Isolated the go doc examples into a separate file

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,11 +1,13 @@
-package osmshortlink
+package osmshortlink_test
 
 import (
 	"fmt"
+
+	"github.com/stefanb/osmshortlink-go"
 )
 
 func ExampleCreate() {
-	shortLink, err := Create(46.05141, 14.50604, 17)
+	shortLink, err := osmshortlink.Create(46.05141, 14.50604, 17)
 	if err != nil {
 		panic(err)
 	}
@@ -14,7 +16,7 @@ func ExampleCreate() {
 }
 
 func ExampleEncode() {
-	shortLink, err := Encode(46.05141, 14.50604, 17)
+	shortLink, err := osmshortlink.Encode(46.05141, 14.50604, 17)
 	if err != nil {
 		panic(err)
 	}
@@ -23,7 +25,7 @@ func ExampleEncode() {
 }
 
 func ExampleDecode() {
-	latitude, longitude, zoom, err := Decode("0Ik3VNr_A-")
+	latitude, longitude, zoom, err := osmshortlink.Decode("0Ik3VNr_A-")
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,32 @@
+package osmshortlink
+
+import (
+	"fmt"
+)
+
+func ExampleCreate() {
+	shortLink, err := Create(46.05141, 14.50604, 17)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(shortLink)
+	// Output: https://osm.org/go/0Ik3VNr_A-?m
+}
+
+func ExampleEncode() {
+	shortLink, err := Encode(46.05141, 14.50604, 17)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(shortLink)
+	// Output: 0Ik3VNr_A-
+}
+
+func ExampleDecode() {
+	latitude, longitude, zoom, err := Decode("0Ik3VNr_A-")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(latitude, longitude, zoom)
+	// Output: 46.05140447616577 14.506051540374756 17
+}

--- a/osmshortlink_test.go
+++ b/osmshortlink_test.go
@@ -1,7 +1,6 @@
 package osmshortlink
 
 import (
-	"fmt"
 	"math"
 	"testing"
 )
@@ -199,31 +198,4 @@ func TestDecodeShortLinkString(t *testing.T) {
 			}
 		})
 	}
-}
-
-func ExampleCreate() {
-	shortLink, err := Create(46.05141, 14.50604, 17)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(shortLink)
-	// Output: https://osm.org/go/0Ik3VNr_A-?m
-}
-
-func ExampleEncode() {
-	shortLink, err := Encode(46.05141, 14.50604, 17)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(shortLink)
-	// Output: 0Ik3VNr_A-
-}
-
-func ExampleDecode() {
-	latitude, longitude, zoom, err := Decode("0Ik3VNr_A-")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(latitude, longitude, zoom)
-	// Output: 46.05140447616577 14.506051540374756 17
 }


### PR DESCRIPTION
Trying to get "Share", "Format" and "Run" buttons below examples on https://pkg.go.dev/github.com/stefanb/osmshortlink-go#pkg-functions

as per 
* https://go.dev/blog/examples
* https://pkg.go.dev/golang.org/x/example/hello/reverse#String
* https://cs.opensource.google/go/x/example/+/master:hello/reverse/example_test.go