### PR TITLE
Bump golangci-lint and fix new warnings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: "stable"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/osmshortlink.go
+++ b/osmshortlink.go
@@ -71,10 +71,10 @@ func Decode(s string) (float64, float64, int, error) {
 	var i int
 	var x int64 = 0
 	var y int64 = 0
-	var z int = -8
+	var z = -8
 	for i = 0; i < len(s); i++ {
-		var digit int = -1
-		var c byte = s[i]
+		var digit = -1
+		var c = s[i]
 		for j := 0; j < len(intToBase64); j++ {
 			if c == intToBase64[j] {
 				digit = j
@@ -98,8 +98,8 @@ func Decode(s string) (float64, float64, int, error) {
 		z += 3
 	}
 
-	var lon float64 = float64(x)*math.Pow(float64(2), float64(2-3*i))*90.0 - float64(180)
-	var lat float64 = float64(y)*math.Pow(float64(2), float64(2-3*i))*45.0 - float64(90)
+	var lon = float64(x)*math.Pow(float64(2), float64(2-3*i))*90.0 - float64(180)
+	var lat = float64(y)*math.Pow(float64(2), float64(2-3*i))*45.0 - float64(90)
 	// adjust z
 	if i < len(s) && s[i] == '-' {
 		z -= 2


### PR DESCRIPTION
1. Bumps golangci linter from v1 to v2 via `latest` supported on golangci-lint-action (#54)
2. Fix linter warnings: `ST1023: should omit type byte from declaration; itwill be inferred from the right-hand side (staticcheck)`

---
Includes #54 :
Bump golangci/golangci-lint-action from 6.2.0 to 7.0.0
Bumps [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action) from 6.2.0 to 7.0.0.
- [Release notes](https://github.com/golangci/golangci-lint-action/releases)
- [Commits](https://github.com/golangci/golangci-lint-action/compare/ec5d18412c0aeab7936cb16880d708ba2a64e1ae...1481404843c368bc19ca9406f87d6e0fc97bdcfd)

---
updated-dependencies:
- dependency-name: golangci/golangci-lint-action dependency-version: 7.0.0 dependency-type: direct:production update-type: version-update:semver-major ...